### PR TITLE
[IR-85] add default container for tags

### DIFF
--- a/config/google_tag.container.default.yml
+++ b/config/google_tag.container.default.yml
@@ -1,0 +1,51 @@
+uuid: 22da8ceb-9e48-4e71-9d18-ad6f592d40ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+id: default
+label: Default
+weight: 0
+container_id: GTM-xxxx
+data_layer: dataLayer
+include_classes: false
+whitelist_classes: |-
+  google
+  nonGooglePixels
+  nonGoogleScripts
+  nonGoogleIframes
+blacklist_classes: |-
+  customScripts
+  customPixels
+include_environment: false
+environment_id: ''
+environment_token: ''
+path_toggle: 'exclude listed'
+path_list: |-
+  /admin*
+  /batch*
+  /node/add*
+  /node/*/edit
+  /node/*/delete
+  /user/*/edit*
+  /user/*/cancel*
+role_toggle: 'exclude listed'
+role_list: {  }
+status_toggle: 'exclude listed'
+status_list: |-
+  403
+  404
+conditions:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    bundles: {  }
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+  'entity_bundle:taxonomy_term':
+    id: 'entity_bundle:taxonomy_term'
+    bundles: {  }
+    negate: false
+    context_mapping:
+      taxonomy_term: '@taxonomy_term.taxonomy_term_route_context:taxonomy_term'


### PR DESCRIPTION
Add container using the same settings as Assessment Registry: https://github.com/UN-OCHA/assessmentregistry8-site/pull/319

(I saw that change but didn't make the connection between 'container' and the tag manager.)