### PR TITLE
[OPS-7850] disable migrate modules

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -34,9 +34,6 @@ module:
   media_library: 0
   menu_ui: 0
   metatag: 0
-  migrate: 0
-  migrate_drupal: 0
-  migrate_drupal_ui: 0
   node: 0
   ocha_integrations: 0
   options: 0


### PR DESCRIPTION
Deploy failed due to dependency of migrate_drupal_ui on dblog. https://jenkins.aws.ahconu.org/job/indicator-dev-deploy/69/console

Disabling migrate modules.