### PR TITLE
[OPS-7459] user expire

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "drupal/seckit": "^2.0",
         "drupal/select2": "^1.8",
         "drupal/social_auth_hid": "^2.6",
+        "drupal/user_expire": "^1.0",
         "drupal/views_data_export": "^1.0",
         "drush/drush": "^10.3",
         "npm-asset/select2": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5eb2cc0414bf835a2cf4f66218d7a021",
+    "content-hash": "8f0ad6262cbf4863a7d68d3cd6afa49e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4089,6 +4089,61 @@
             "homepage": "https://www.drupal.org/project/token",
             "support": {
                 "source": "https://git.drupalcode.org/project/token"
+            }
+        },
+        {
+            "name": "drupal/user_expire",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/user_expire.git",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/user_expire-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "70c5ebffe7f28f97c270de0c004dbfd4c174ffb8"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1633965091",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Erik Webb (erikwebb)",
+                    "homepage": "https://www.drupal.org/u/erikwebb",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Greg Knaddison (greggles)",
+                    "homepage": "https://www.drupal.org/u/greggles",
+                    "role": "Co-maintainer"
+                },
+                {
+                    "name": "shelane",
+                    "homepage": "https://www.drupal.org/user/2674989"
+                }
+            ],
+            "description": "Allows an administrator to define a date on which to expire a user account.",
+            "homepage": "https://www.drupal.org/project/user_expire",
+            "support": {
+                "source": "https://git.drupal.org/project/user_expire.git",
+                "issues": "https://www.drupal.org/project/issues/user_expire"
             }
         },
         {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -5,6 +5,10 @@
     },
     "drupal/select2": {
       "https://www.drupal.org/project/select2/issues/3078085": "https://www.drupal.org/files/issues/2020-02-27/hierarchical-facet-widget-3078085-2.patch"
+    },
+    "drupal/user_expire": {
+      "Allow the notification email to be customised": "https://git.drupalcode.org/project/user_expire/-/merge_requests/5.diff",
+      "Reset expiration when user is reactivated": "https://git.drupalcode.org/project/user_expire/-/merge_requests/6.diff"
     }
   }
 }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
   automated_cron: 0
   big_pipe: 0
@@ -62,6 +64,7 @@ module:
   token: 0
   toolbar: 0
   user: 0
+  user_expire: 0
   views_data_export: 0
   menu_link_content: 1
   pathauto: 1
@@ -74,5 +77,3 @@ theme:
   common_design: 0
   common_design_subtheme: 0
 profile: standard
-_core:
-  default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc

--- a/config/user_expire.settings.yml
+++ b/config/user_expire.settings.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: PeDvVH4C3IZ7QFkvC1BUv3BZJVc7jLwQmJAEttVuVOw
+frequency: 432000
+offset: 604800
+user_expire_roles:
+  authenticated: 15552000


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/OPS-7459

Adds and configures user_expire with the patches mentioned in https://github.com/UN-OCHA/assessmentregistry8-site/pull/360

Instead of https://github.com/UN-OCHA/indicatorregistry8-site/pull/125 - this directly to the main branch.